### PR TITLE
Displaying Unformatted screens as Input field

### DIFF
--- a/src/main/java/net/sf/f3270/Terminal.java
+++ b/src/main/java/net/sf/f3270/Terminal.java
@@ -28,6 +28,7 @@ public class Terminal {
 	private final boolean showTerminalWindow;
     private static final char MAINFRAME_BLANK_CHAR = '\u0000';
     private static final char SINGLE_SPACE = ' ';
+    private static final String MASKED_VALUE = "****";
 
     public Terminal(final String s3270Path, final String hostname, final int port, final TerminalType type,
             final TerminalMode mode, final boolean showTerminalWindow) {
@@ -202,8 +203,9 @@ public class Terminal {
 
     public void write(FieldIdentifier fieldIdentifier, String value) {
         assertConnected();
-        getInputField(fieldIdentifier).setValue(value);
-        commandIssued("write", null, buildParameters(fieldIdentifier, value));
+        InputField inputField = getInputField(fieldIdentifier);
+        inputField.setValue(value);
+        commandIssued("write", null, buildParameters(fieldIdentifier, getMaskedValueIfFieldIsHidden(inputField, value)));
     }
     
     public void write(FieldIdentifier fieldIdentifier, int lineNumber, String value) {
@@ -213,7 +215,11 @@ public class Terminal {
         	throw new RuntimeException("write method with Line Number can be used only with multi-line input field");
         }
 		inputField.setValue(lineNumber, value);
-        commandIssued("write", null, buildParameters(fieldIdentifier, value));
+        commandIssued("write", null, buildParameters(fieldIdentifier, getMaskedValueIfFieldIsHidden(inputField, value)));
+    }
+    
+    private String getMaskedValueIfFieldIsHidden(InputField inputField, String value) {
+        return inputField.isHidden()? MASKED_VALUE : value;
     }
 
     /**

--- a/src/main/java/net/sf/f3270/Terminal.java
+++ b/src/main/java/net/sf/f3270/Terminal.java
@@ -205,6 +205,16 @@ public class Terminal {
         getInputField(fieldIdentifier).setValue(value);
         commandIssued("write", null, buildParameters(fieldIdentifier, value));
     }
+    
+    public void write(FieldIdentifier fieldIdentifier, int lineNumber, String value) {
+        assertConnected();
+        InputField inputField = getInputField(fieldIdentifier);
+        if(!inputField.isMultiline()){
+        	throw new RuntimeException("write method with Line Number can be used only with multi-line input field");
+        }
+		inputField.setValue(lineNumber, value);
+        commandIssued("write", null, buildParameters(fieldIdentifier, value));
+    }
 
     /**
      * @deprecated Use {@link @link Terminal#read (FieldIdentifier)} instead

--- a/src/main/java/net/sf/f3270/TerminalWindow.java
+++ b/src/main/java/net/sf/f3270/TerminalWindow.java
@@ -35,12 +35,14 @@ import org.h3270.host.S3270;
 
 public class TerminalWindow {
 	
-	private S3270 s3270;
+	private static final String MASKED_VALUE = "****";
+    private S3270 s3270;
 	private int currentWidth;
 	private int currentHeight;
 
 	private Style styleInputChanged;
 	private Style styleInput;
+	private Style styleHidden;
 	private Style styleBlack;
 
 	private Style styleCommand;
@@ -83,6 +85,7 @@ public class TerminalWindow {
 	private void initializeStyles() {
 		styleInputChanged = createStyle(Color.black, Color.red, false);
 		styleInput = createStyle(Color.green, Color.black, false);
+		styleHidden= createStyle(Color.black, Color.black, false);
 		styleCommand = createStyle(Color.black, Color.white, false);
 		stylePunctuation = createStyle(Color.gray, Color.white, false);
 		styleReturn = createStyle(Color.magenta, Color.white, false);
@@ -159,6 +162,10 @@ public class TerminalWindow {
 
 	private Style getStyle(final Field f) {
 		final boolean isInput = f instanceof InputField;
+        if (f.isHidden()) {
+            return styleHidden;   
+        }
+        
 		if (isInput) {
 			final InputField inputField = (InputField) f;
 			if (inputField.isChanged()) {
@@ -182,13 +189,6 @@ public class TerminalWindow {
 		if (f.isIntensified()) {
 			foregroundColor = Color.white;
 		}
-
-		if (f.isHidden()) {
-			foregroundColor = Color.black;
-			backgroundColor = Color.black;
-			isUnderline = false;
-		}
-
 		return createStyle(foregroundColor, backgroundColor, isUnderline);
 	}
 
@@ -325,11 +325,16 @@ public class TerminalWindow {
 									.isChanged()) ? " *" : "");
 				}
 				if (columnIndex == 2) {
-					return "[" + f.getValue().replace('\u0000', ' ') + "]";
+					return getMaskedValueIfFieldIsHidden(f);
 				}
 				throw new RuntimeException("unknown column index "
 						+ columnIndex);
 			}
+
+            private String getMaskedValueIfFieldIsHidden(Field f) {
+                String value = f.isHidden() ? MASKED_VALUE : f.getValue().replace('\u0000', ' ');
+                return "[" + value + "]";
+            }
 
 			public boolean isCellEditable(final int rowIndex,
 					final int columnIndex) {

--- a/src/main/java/org/h3270/host/S3270Screen.java
+++ b/src/main/java/org/h3270/host/S3270Screen.java
@@ -268,7 +268,7 @@ public class S3270Screen extends AbstractScreen {
 
     private Field createField(final byte startCode, final int startx, final int starty, final int endx, final int endy,
             final int color, final int extHighlight) {
-        if ((startCode & Field.ATTR_PROTECTED) == 0) {
+        if ((startCode & Field.ATTR_PROTECTED) == 0 || !isFormatted) {
             return new InputField(this, startCode, startx, starty, endx, endy, color, extHighlight);
         } else {
             return new Field(this, startCode, startx, starty, endx, endy, color, extHighlight);


### PR DESCRIPTION
I have modified the S3270Screen.java class - createField method to create an InputField if the screen is "Unformatted". This change is in-line with how H3270 interprets unformatted screens as Input field.

Also, since the input field has multiple lines, I was not able to use the normal Terminal.write() function. I have added a overloaded method in Terminal.java file to accept the line number.
